### PR TITLE
Add zoom/focus speed control

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
 		"useTabs": true,
 		"endOfLine": "lf",
 		"trailingComma": "es5"
-	}
+	},
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -32,9 +32,9 @@ const speedOperation = {
 	type: 'dropdown',
 	label: 'Speed Change',
 	id: 'op',
-	default: ACTION_SET,
+	default: ACTION_STOP,
 	choices: [
-		{ id: ACTION_SET, label: 'Set Speed' },
+		{ id: ACTION_STOP, label: 'Reset Speed (Stop)' },
 		{ id: ACTION_RAISE, label: 'Raise Speed' },
 		{ id: ACTION_LOWER, label: 'Lower Speed' },
 	],
@@ -58,7 +58,7 @@ function optMove(label_inc = '⬆', label_dec = '⬇') {
 			type: 'dropdown',
 			label: 'Direction',
 			id: 'dir',
-			default: 0,
+			default: ACTION_STOP,
 			choices: [
 				{ id: ACTION_STOP, label: 'Stop' },
 				{ id: ACTION_INC, label: label_inc },
@@ -363,7 +363,7 @@ export function getActionDefinitions(self) {
 			name: 'Lens - Zoom Control',
 			options: optMoveVar(),
 			callback: async (action) => {
-				self.zSpeed = action.options.op !== ACTION_SET ? constrainRange(self.zSpeed + action.options.step * action.options.op, -SPEED_MAX, SPEED_MAX) : action.options.set
+				self.zSpeed = action.options.op !== ACTION_STOP ? constrainRange(self.zSpeed + action.options.step * action.options.op, -SPEED_MAX, SPEED_MAX) : 0
 				await self.getPTZ('Z' + cmdSpeed(self.zSpeed + SPEED_OFFSET))
 			},
 		}

--- a/src/actions.js
+++ b/src/actions.js
@@ -52,6 +52,18 @@ const speedSetting = {
 	isVisible: (options) => options.op === 's',
 }
 
+const speedControlSetting = {
+	type: 'number',
+	label: 'Direct speed setting',
+	id: 'set',
+	default: SPEED_MIN,
+	min: -SPEED_MAX,
+	max: SPEED_MAX,
+	required: true,
+	range: true,
+	isVisible: (options) => options.op === 's',
+}
+
 const speedStep = {
 	id: 'step',
 	type: 'number',
@@ -357,10 +369,10 @@ export function getActionDefinitions(self) {
 
 		actions.zoomControl = {
 			name: 'Lens - Zoom Speed Control',
-			options: [speedOperation, speedSetting, speedStep],
+			options: [speedOperation, speedControlSetting, speedStep],
 			callback: async (action) => {
-				self.data.zoomSpeed = action.options.op !== ACTION_SET ? getNextValue(self.data.zoomSpeed, -SPEED_MAX, SPEED_MAX, action.options.op * action.options.step) : action.options.set
-				await self.getPTZ('Z' + cmdSpeed(self.data.zoomSpeed + SPEED_OFFSET))
+				self.data.zoomSpeedValue = action.options.op !== ACTION_SET ? getNextValue(self.data.zoomSpeedValue, -SPEED_MAX, SPEED_MAX, action.options.op * action.options.step) : action.options.set
+				await self.getPTZ('Z' + cmdSpeed(self.data.zoomSpeedValue + SPEED_OFFSET))
 			},
 		}
 
@@ -394,10 +406,10 @@ export function getActionDefinitions(self) {
 
 		actions.focusControl = {
 			name: 'Lens - Focus Speed Control',
-			options: [speedOperation, speedSetting, speedStep],
+			options: [speedOperation, speedControlSetting, speedStep],
 			callback: async (action) => {
-				self.data.focusSpeed = action.options.op !== ACTION_SET ? getNextValue(self.data.focusSpeed, -SPEED_MAX, SPEED_MAX, action.options.op * action.options.step) : action.options.set
-				await self.getPTZ('F' + cmdSpeed(self.data.focusSpeed + SPEED_OFFSET))
+				self.data.focusSpeedValue = action.options.op !== ACTION_SET ? getNextValue(self.data.focusSpeedValue, -SPEED_MAX, SPEED_MAX, action.options.op * action.options.step) : action.options.set
+				await self.getPTZ('F' + cmdSpeed(self.data.focusSpeedValue + SPEED_OFFSET))
 			},
 		}
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -392,6 +392,15 @@ export function getActionDefinitions(self) {
 			},
 		}
 
+		actions.focusControl = {
+			name: 'Lens - Focus Speed Control',
+			options: [speedOperation, speedSetting, speedStep],
+			callback: async (action) => {
+				self.data.focusSpeed = action.options.op !== ACTION_SET ? getNextValue(self.data.focusSpeed, -SPEED_MAX, SPEED_MAX, action.options.op * action.options.step) : action.options.set
+				await self.getPTZ('F' + cmdSpeed(self.data.focusSpeed + SPEED_OFFSET))
+			},
+		}
+
 		actions.focusSpeed = {
 			name: 'Lens - Focus Speed',
 			options: [speedOperation, speedSetting, speedStep],

--- a/src/actions.js
+++ b/src/actions.js
@@ -356,11 +356,11 @@ export function getActionDefinitions(self) {
 		}
 
 		actions.zoomControl = {
-			name: 'Lens - Zoom Control',
+			name: 'Lens - Zoom Speed Control',
 			options: [speedOperation, speedSetting, speedStep],
 			callback: async (action) => {
-				self.zSpeedDir = action.options.op !== ACTION_SET ? getNextValue(self.zSpeedDir, -SPEED_MAX, SPEED_MAX, action.options.op * action.options.step) : action.options.set
-				await self.getPTZ('Z' + cmdSpeed(self.zSpeedDir + SPEED_OFFSET))
+				self.data.zoomSpeed = action.options.op !== ACTION_SET ? getNextValue(self.data.zoomSpeed, -SPEED_MAX, SPEED_MAX, action.options.op * action.options.step) : action.options.set
+				await self.getPTZ('Z' + cmdSpeed(self.data.zoomSpeed + SPEED_OFFSET))
 			},
 		}
 

--- a/src/common.js
+++ b/src/common.js
@@ -50,9 +50,8 @@ export function toHexString(value, length) {
 	return parseInt(value).toString(16).toUpperCase().padStart(length, '0')
 }
 
-export function parseIntConstrained(value, min, max) {
-	let v = parseInt(value)
-	if (v > max) return max
-	if (v < min) return min
-	return v
+export function constrainRange(value, min, max) {
+	if (value > max) return max
+	if (value < min) return min
+	return value
 }

--- a/src/common.js
+++ b/src/common.js
@@ -32,14 +32,7 @@ export function getNext(values, key, step = 1, overrun = true) {
 }
 
 export function getNextValue(value, min, max, step = 1) {
-	let v = (value += step)
-	if (v > max) {
-		v = max
-	}
-	if (v < min) {
-		v = min
-	}
-	return v
+	return constrainRange(value + step, min, max)
 }
 
 export function getLabel(values, key) {

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -196,6 +196,22 @@ export function getFeedbackDefinitions(self) {
 		}
 	}
 
+	if (SERIES.capabilities.zoom) {
+		feedbacks.zoomControl = {
+			type: 'boolean',
+			name: 'Lens - Zoom Control',
+			description: 'Indicates if Zoom is currently in operation',
+			defaultStyle: {
+				color: colorWhite,
+				bgcolor: colorRed,
+			},
+			options: [],
+			callback: function () {
+				return self.data.zoomSpeedValue != 0
+			},
+		}
+	}
+
 	if (SERIES.capabilities.trackingAuto) {
 		feedbacks.autotrackingMode = {
 			type: 'boolean',

--- a/src/index.js
+++ b/src/index.js
@@ -385,6 +385,7 @@ class PanasonicCameraInstance extends InstanceBase {
 			zoomPosition: null,
 
 			// numeric signed values
+			focusSpeedValue: 0,
 			redGainValue: 0,
 			blueGainValue: 0,
 			redPedValue: 0,

--- a/src/index.js
+++ b/src/index.js
@@ -411,6 +411,8 @@ class PanasonicCameraInstance extends InstanceBase {
 		this.zSpeed = 25
 		this.fSpeed = 25
 
+		this.zSpeedDir = 0
+
 		this.tcpPortSelected = 31004
 		this.tcpPortOld = this.config.tcpPort || 31004
 

--- a/src/index.js
+++ b/src/index.js
@@ -391,6 +391,7 @@ class PanasonicCameraInstance extends InstanceBase {
 			bluePedValue: 0,
 			//greenPedValue: 0,
 			masterPedValue: 0,
+			zoomSpeedValue: 0,
 
 			// other strings
 			colorTempLabel: null,
@@ -410,8 +411,6 @@ class PanasonicCameraInstance extends InstanceBase {
 		this.tSpeed = 25
 		this.zSpeed = 25
 		this.fSpeed = 25
-
-		this.zSpeedDir = 0
 
 		this.tcpPortSelected = 31004
 		this.tcpPortOld = this.config.tcpPort || 31004

--- a/src/parser.js
+++ b/src/parser.js
@@ -128,6 +128,10 @@ export function parseUpdate(self, str) {
 		self.data.presetSpeed = str[0].substring(4)
 	}
 
+	if (str[0].substring(0, 2) === 'zS') {
+		self.data.zoomSpeedValue = parseInt(str[0].substring(2, 4)) - 50
+	}
+
 	switch (str[0]) {
 		case 'dA0':
 			self.data.tally = '0'

--- a/src/parser.js
+++ b/src/parser.js
@@ -128,6 +128,10 @@ export function parseUpdate(self, str) {
 		self.data.presetSpeed = str[0].substring(4)
 	}
 
+	if (str[0].substring(0, 2) === 'fS') {
+		self.data.focusSpeedValue = parseInt(str[0].substring(2, 4)) - 50
+	}
+
 	if (str[0].substring(0, 2) === 'zS') {
 		self.data.zoomSpeedValue = parseInt(str[0].substring(2, 4)) - 50
 	}

--- a/src/presets.js
+++ b/src/presets.js
@@ -365,6 +365,7 @@ export function getPresetDefinitions(self) {
 							options: {
 								scope: 'pt',
 								op: -1,
+								step: 1,
 							},
 						},
 					],
@@ -374,6 +375,7 @@ export function getPresetDefinitions(self) {
 							options: {
 								scope: 'pt',
 								op: 1,
+								step: 1,
 							},
 						},
 					],
@@ -2096,7 +2098,7 @@ export function getPresetDefinitions(self) {
 							actionId: 'presetSpeedTime',
 							options: {
 								op: 's',
-								set: '875',
+								set: '999',
 							},
 						},
 					],
@@ -2107,7 +2109,7 @@ export function getPresetDefinitions(self) {
 				{
 					feedbackId: 'presetSpeedTime',
 					options: {
-						option: '875',
+						option: '999',
 					},
 					style: {
 						color: colorWhite,
@@ -2172,7 +2174,7 @@ export function getPresetDefinitions(self) {
 							actionId: 'presetSpeedTime',
 							options: {
 								op: 's',
-								set: '375',
+								set: '275',
 							},
 						},
 					],
@@ -2183,7 +2185,7 @@ export function getPresetDefinitions(self) {
 				{
 					feedbackId: 'presetSpeedTime',
 					options: {
-						option: '375',
+						option: '275',
 					},
 					style: {
 						color: colorWhite,

--- a/src/presets.js
+++ b/src/presets.js
@@ -398,7 +398,32 @@ export function getPresetDefinitions(self) {
 				color: colorWhite,
 				bgcolor: colorBlack,
 			},
-			steps: [],
+			options: {
+				rotaryActions: true,
+			},
+			steps: [
+				{
+					down: [
+						{
+							actionId: 'zoomSpeed',
+							options: { op: 0 },
+						},
+					],
+					up: [],
+					rotate_left: [
+						{
+							actionId: 'zoomControl',
+							options: { op: -1, step: 7 },
+						},
+					],
+					rotate_right: [
+						{
+							actionId: 'zoomControl',
+							options: { op: 1, step: 7 },
+						},
+					],
+				},
+			],
 			feedbacks: [],
 		}
 
@@ -458,7 +483,7 @@ export function getPresetDefinitions(self) {
 					down: [
 						{
 							actionId: 'zoomSpeed',
-							options: { op: 's', set: 25 },
+							options: { op: 0 },
 						},
 					],
 					up: [],

--- a/src/presets.js
+++ b/src/presets.js
@@ -597,7 +597,7 @@ export function getPresetDefinitions(self) {
 			category: 'Lens',
 			name: 'Focus Speed',
 			style: {
-				text: 'Focus\\nSpeed\\n$(generic-module:zSpeed)',
+				text: 'Focus\\nSpeed\\n$(generic-module:fSpeed)',
 				size: '14',
 				color: colorWhite,
 				bgcolor: colorBlack,

--- a/src/presets.js
+++ b/src/presets.js
@@ -426,7 +426,15 @@ export function getPresetDefinitions(self) {
 					],
 				},
 			],
-			feedbacks: [],
+			feedbacks: [
+				{
+					feedbackId: 'zoomControl',
+					style: {
+						color: colorWhite,
+						bgcolor: colorRed,
+					},
+				},
+			],
 		}
 
 		presets['lens-zoom-in'] = {

--- a/src/presets.js
+++ b/src/presets.js
@@ -405,8 +405,8 @@ export function getPresetDefinitions(self) {
 				{
 					down: [
 						{
-							actionId: 'zoomSpeed',
-							options: { op: 0 },
+							actionId: 'zoomControl',
+							options: { op: 's', set: 0 },
 						},
 					],
 					up: [],
@@ -483,20 +483,20 @@ export function getPresetDefinitions(self) {
 					down: [
 						{
 							actionId: 'zoomSpeed',
-							options: { op: 0 },
+							options: { op: 's', set: 25 },
 						},
 					],
 					up: [],
 					rotate_left: [
 						{
 							actionId: 'zoomSpeed',
-							options: { op: -1 },
+							options: { op: -1, step: 1 },
 						},
 					],
 					rotate_right: [
 						{
 							actionId: 'zoomSpeed',
-							options: { op: 1 },
+							options: { op: 1, step: 1 },
 						},
 					],
 				},
@@ -615,13 +615,13 @@ export function getPresetDefinitions(self) {
 					rotate_left: [
 						{
 							actionId: 'focusSpeed',
-							options: { op: -1 },
+							options: { op: -1, step: 1 },
 						},
 					],
 					rotate_right: [
 						{
 							actionId: 'focusSpeed',
-							options: { op: 1 },
+							options: { op: 1, step: 1 },
 						},
 					],
 				},

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -25,4 +25,23 @@ export const upgradeScripts = [
 		}
 		return result
 	},
+	function addSetStepSize(_context, props) {
+		const result = {
+			updatedActions: [],
+			updatedConfig: null,
+			updatedFeedbacks: [],
+		}
+
+		for (const action of props.actions) {
+			switch (action.actionId) {
+				case 'ptSpeed':
+				case 'zoomSpeed':
+				case 'focusSpeed':
+					action.options.step = action.options.step === undefined ? 1 : action.options.step
+					result.updatedActions.push(action)
+					break
+			}
+		}
+		return result
+	},
 ]

--- a/src/variables.js
+++ b/src/variables.js
@@ -81,6 +81,7 @@ export function setVariables(self) {
 		variables.push({ variableId: 'zoomPositionPct', name: 'Zoom Position %' })
 		variables.push({ variableId: 'zoomPositionBar', name: 'Zoom Position' })
 		variables.push({ variableId: 'zSpeed', name: 'Zoom Speed' })
+		variables.push({ variableId: 'zSpeedDir', name: 'Zoom Speed and Direction' })
 	}
 	if (SERIES.capabilities.focus) {
 		variables.push({ variableId: 'focusPosition', name: 'Focus Position' })
@@ -280,5 +281,6 @@ export function checkVariables(self) {
 		tSpeed: self.tSpeed,
 		zSpeed: self.zSpeed,
 		fSpeed: self.fSpeed,
+		fSpeedDir: self.zSpeedDir,
 	})
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -1,4 +1,4 @@
-import { getAndUpdateSeries, getLabel } from './common.js'
+import { constrainRange, getAndUpdateSeries, getLabel } from './common.js'
 import { e } from './enum.js'
 
 // ##########################
@@ -209,10 +209,7 @@ export function checkVariables(self) {
 	}
 
 	const normalizePct = (val, low = 0, high = 100, limit = false, fractionDigits = 0) => {
-		if (limit) {
-			val = val < low ? low : val
-			val = val > high ? high : val
-		}
+		val = limit ? constrainRange(val, low, high) : val
 		return val < low || val > high ? null : (((val - low) / (high - low)) * 100).toFixed(fractionDigits)
 	}
 

--- a/src/variables.js
+++ b/src/variables.js
@@ -239,13 +239,13 @@ export function checkVariables(self) {
 
 		irisVolume: self.data.irisVolume,
 
-		focusSpeed: self.data.focusSpeed,
+		focusSpeed: self.data.focusSpeedValue,
 		redGain: self.data.redGainValue,
 		blueGain: self.data.blueGainValue,
 		redPed: self.data.redPedValue,
 		bluePed: self.data.bluePedValue,
 		masterPed: self.data.masterPedValue,
-		zoomSpeed: self.data.zoomSpeed,
+		zoomSpeed: self.data.zoomSpeedValue,
 
 		irisF: self.data.irisLabel,
 		shutterStep: self.data.shutterStepLabel,

--- a/src/variables.js
+++ b/src/variables.js
@@ -87,6 +87,7 @@ export function setVariables(self) {
 		variables.push({ variableId: 'focusPosition', name: 'Focus Position' })
 		variables.push({ variableId: 'focusPositionPct', name: 'Focus Position %' })
 		variables.push({ variableId: 'focusPositionBar', name: 'Focus Position' })
+		variables.push({ variableId: 'focusSpeed', name: 'Focus Speed Control' })
 		variables.push({ variableId: 'fSpeed', name: 'Focus Speed' })
 	}
 	if (SERIES.capabilities.iris) {
@@ -238,6 +239,7 @@ export function checkVariables(self) {
 
 		irisVolume: self.data.irisVolume,
 
+		focusSpeed: self.data.focusSpeed,
 		redGain: self.data.redGainValue,
 		blueGain: self.data.blueGainValue,
 		redPed: self.data.redPedValue,

--- a/src/variables.js
+++ b/src/variables.js
@@ -80,8 +80,8 @@ export function setVariables(self) {
 		variables.push({ variableId: 'zoomPosition', name: 'Zoom Position' })
 		variables.push({ variableId: 'zoomPositionPct', name: 'Zoom Position %' })
 		variables.push({ variableId: 'zoomPositionBar', name: 'Zoom Position' })
+		variables.push({ variableId: 'zoomSpeed', name: 'Zoom Speed Control' })
 		variables.push({ variableId: 'zSpeed', name: 'Zoom Speed' })
-		variables.push({ variableId: 'zSpeedDir', name: 'Zoom Speed and Direction' })
 	}
 	if (SERIES.capabilities.focus) {
 		variables.push({ variableId: 'focusPosition', name: 'Focus Position' })
@@ -243,6 +243,7 @@ export function checkVariables(self) {
 		redPed: self.data.redPedValue,
 		bluePed: self.data.bluePedValue,
 		masterPed: self.data.masterPedValue,
+		zoomSpeed: self.data.zoomSpeed,
 
 		irisF: self.data.irisLabel,
 		shutterStep: self.data.shutterStepLabel,
@@ -281,6 +282,5 @@ export function checkVariables(self) {
 		tSpeed: self.tSpeed,
 		zSpeed: self.zSpeed,
 		fSpeed: self.fSpeed,
-		fSpeedDir: self.zSpeedDir,
 	})
 }


### PR DESCRIPTION
Adds actions to allow controllers like the Contour Shuttle ShuttlePro v2 to operate variable zoom (and focus) speed control on the shuttle wheel or on any other rotary encoder.

Additionally adds step size control on all speed related actions.

ToDo:
- [x] Upgrade script (Step size)