### PR TITLE
Allow variable for preset number in actions and feedbacks

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -835,7 +835,7 @@ export function getActionDefinitions(self) {
 					type: 'dropdown',
 					label: 'Action',
 					id: 'op',
-					default: e.ENUM_PRESET[0].id,
+					default: 'R',
 					choices: [
 						{ id: 'R', label: 'Recall / Play' },
 						{ id: 'M', label: 'Memorize / Save' },
@@ -844,14 +844,38 @@ export function getActionDefinitions(self) {
 				},
 				{
 					type: 'dropdown',
-					label: 'Preset Nr.',
+					label: 'Preset #',
 					id: 'val',
 					default: e.ENUM_PRESET[0].id,
 					choices: e.ENUM_PRESET,
+					isVisible: (options) => !options.useVar,
+				},
+				{
+					id: 'valVar',
+					type: 'textinput',
+					label: 'Preset # variable',
+					default: '1',
+					regex: Regex.SOMETHING,
+					required: true,
+					useVariables: true,
+					tooltip: `This expression should return a preset number in the range 1 to ${SERIES.capabilities.preset}. Numeric values outside this range will be constrained to this range. Invalid (unreadable) values will result in no action being taken.`,
+					isVisible: (options) => options.useVar,
+				},
+				{
+					id: 'useVar',
+					type: 'checkbox',
+					label: 'Use Variable',
+					default: false,
 				},
 			],
 			callback: async (action) => {
-				await self.getPTZ(action.options.op + action.options.val)
+				let val = action.options.val
+				if (action.options.useVar) {
+					const num = constrainRange(parseInt(await self.parseVariablesInString(action.options.valVar)), 1, SERIES.capabilities.preset)
+					if (isNaN(num)) return
+					val = (num - 1).toString(10).padStart(2, '0')
+				}
+				await self.getPTZ(action.options.op + val)
 			},
 		}
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -847,7 +847,7 @@ export function getActionDefinitions(self) {
 					label: 'Preset #',
 					id: 'val',
 					default: e.ENUM_PRESET[0].id,
-					choices: e.ENUM_PRESET,
+					choices: e.ENUM_PRESET.slice(0, SERIES.capabilities.preset),
 					isVisible: (options) => !options.useVar,
 				},
 				{

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -11,7 +11,7 @@ function optPreset(max) {
 			label: 'Preset',
 			id: 'option',
 			default: e.ENUM_PRESET[0].id,
-			choices: e.ENUM_PRESET,
+			choices: e.ENUM_PRESET.slice(0, max),
 			isVisible: (options) => !options.useVar,
 		},
 		{

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -1,7 +1,48 @@
-import { combineRgb } from '@companion-module/base'
-import { getAndUpdateSeries } from './common.js'
+import { combineRgb, Regex } from '@companion-module/base'
+import { getAndUpdateSeries, constrainRange } from './common.js'
 import { e } from './enum.js'
 import ICONS from './icons.js'
+
+// Preset number option set with optional variable support (dropdown / variable toggled by checkbox)
+function optPreset(max) {
+	return [
+		{
+			type: 'dropdown',
+			label: 'Preset',
+			id: 'option',
+			default: e.ENUM_PRESET[0].id,
+			choices: e.ENUM_PRESET,
+			isVisible: (options) => !options.useVar,
+		},
+		{
+			id: 'optionVar',
+			type: 'textinput',
+			label: 'Preset # variable',
+			default: '1',
+			regex: Regex.SOMETHING,
+			required: true,
+			useVariables: true,
+			tooltip: `This expression should return a preset number in the range 1 to ${max}. Numeric values outside this range will be constrained to this range. Invalid (unreadable) values disable the feedback.`,
+			isVisible: (options) => options.useVar,
+		},
+		{
+			id: 'useVar',
+			type: 'checkbox',
+			label: 'Use Variable',
+			default: false,
+		},
+	]
+}
+
+// Resolve the selected preset to its 0-based index, or null when a variable expression is unreadable
+async function parsePresetIdx(feedback, context, max) {
+	if (feedback.options.useVar) {
+		const num = constrainRange(parseInt(await context.parseVariablesInString(feedback.options.optionVar)), 1, max)
+		if (isNaN(num)) return null
+		return num - 1
+	}
+	return parseInt(feedback.options.option)
+}
 
 // ##########################
 // #### Define Feedbacks ####
@@ -325,17 +366,11 @@ export function getFeedbackDefinitions(self) {
 				color: colorWhite,
 				bgcolor: colorOrange,
 			},
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Preset',
-					id: 'option',
-					default: e.ENUM_PRESET[0].id,
-					choices: e.ENUM_PRESET,
-				},
-			],
-			callback: function (feedback) {
-				return self.data.presetEntries[parseInt(feedback.options.option)] === '1' && self.data.presetSelectedIdx === parseInt(feedback.options.option)
+			options: optPreset(SERIES.capabilities.preset),
+			callback: async (feedback, context) => {
+				const idx = await parsePresetIdx(feedback, context, SERIES.capabilities.preset)
+				if (idx === null) return false
+				return self.data.presetEntries[idx] === '1' && self.data.presetSelectedIdx === idx
 			},
 		}
 
@@ -347,17 +382,11 @@ export function getFeedbackDefinitions(self) {
 				color: colorWhite,
 				bgcolor: colorBlue,
 			},
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Preset',
-					id: 'option',
-					default: e.ENUM_PRESET[0].id,
-					choices: e.ENUM_PRESET,
-				},
-			],
-			callback: function (feedback) {
-				return self.data.presetEntries[parseInt(feedback.options.option)] === '1' && self.data.presetCompletedIdx === parseInt(feedback.options.option)
+			options: optPreset(SERIES.capabilities.preset),
+			callback: async (feedback, context) => {
+				const idx = await parsePresetIdx(feedback, context, SERIES.capabilities.preset)
+				if (idx === null) return false
+				return self.data.presetEntries[idx] === '1' && self.data.presetCompletedIdx === idx
 			},
 		}
 
@@ -369,17 +398,11 @@ export function getFeedbackDefinitions(self) {
 				color: colorWhite,
 				bgcolor: colorGrey,
 			},
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Preset',
-					id: 'option',
-					default: e.ENUM_PRESET[0].id,
-					choices: e.ENUM_PRESET,
-				},
-			],
-			callback: function (feedback) {
-				return self.data.presetEntries[parseInt(feedback.options.option)] === '1'
+			options: optPreset(SERIES.capabilities.preset),
+			callback: async (feedback, context) => {
+				const idx = await parsePresetIdx(feedback, context, SERIES.capabilities.preset)
+				if (idx === null) return false
+				return self.data.presetEntries[idx] === '1'
 			},
 		}
 
@@ -388,18 +411,11 @@ export function getFeedbackDefinitions(self) {
 				type: 'advanced',
 				name: 'Preset - Thumbnail',
 				description: 'Provides the thumbnail of the selected preset as the button background image',
-				options: [
-					{
-						type: 'dropdown',
-						label: 'Preset',
-						id: 'option',
-						default: e.ENUM_PRESET[0].id,
-						choices: e.ENUM_PRESET,
-					},
-				],
-				callback: function (feedback) {
-					const id = parseInt(feedback.options.option)
-					return { png64: self.data.presetThumbnails[id] }
+				options: optPreset(SERIES.capabilities.preset),
+				callback: async (feedback, context) => {
+					const idx = await parsePresetIdx(feedback, context, SERIES.capabilities.preset)
+					if (idx === null) return {}
+					return { png64: self.data.presetThumbnails[idx] }
 				},
 			}
 		}

--- a/src/presets.js
+++ b/src/presets.js
@@ -2703,6 +2703,7 @@ export function getPresetDefinitions(self) {
 								options: {
 									op: 'R',
 									val: i.toString(10).padStart(2, '0'),
+									useVar: false,
 								},
 							},
 						],
@@ -2714,6 +2715,7 @@ export function getPresetDefinitions(self) {
 									options: {
 										op: 'M',
 										val: i.toString(10).padStart(2, '0'),
+										useVar: false,
 									},
 								},
 							],
@@ -2726,6 +2728,7 @@ export function getPresetDefinitions(self) {
 									options: {
 										op: 'C',
 										val: i.toString(10).padStart(2, '0'),
+										useVar: false,
 									},
 								},
 							],
@@ -2737,6 +2740,7 @@ export function getPresetDefinitions(self) {
 						feedbackId: 'presetMemory',
 						options: {
 							option: i.toString(10).padStart(2, '0'),
+							useVar: false,
 						},
 						style: {
 							color: colorWhite,
@@ -2749,6 +2753,7 @@ export function getPresetDefinitions(self) {
 									feedbackId: 'presetThumbnail',
 									options: {
 										option: i.toString(10).padStart(2, '0'),
+										useVar: false,
 									},
 								},
 							]
@@ -2757,6 +2762,7 @@ export function getPresetDefinitions(self) {
 						feedbackId: 'presetSelected',
 						options: {
 							option: i.toString(10).padStart(2, '0'),
+							useVar: false,
 						},
 						style: {
 							color: colorWhite,
@@ -2767,6 +2773,7 @@ export function getPresetDefinitions(self) {
 						feedbackId: 'presetComplete',
 						options: {
 							option: i.toString(10).padStart(2, '0'),
+							useVar: false,
 						},
 						style: {
 							color: colorWhite,


### PR DESCRIPTION
Fixes #42

## What

The "Preset - Memory Operation" action and the preset-number based feedbacks now optionally accept a **variable/expression** for the preset number instead of only the fixed dropdown. A **"Use Variable"** checkbox toggles between the dropdown and a variable input field — following the pattern already established for pan/tilt speed (#29).

Affected:
- Action **Preset - Memory Operation** (Recall / Memorize / Clear)
- Feedbacks **Preset - Selected / Active**, **Recall Completion Notification**, **Memory State**, **Thumbnail**

The variable uses the human preset number (`1..N`), is clamped to the camera's valid range (`SERIES.capabilities.preset`) and mapped internally to the wire value (`num - 1`, two-digit decimal). Unreadable values result in no action / disable the feedback. Feedbacks use `context.parseVariablesInString` so they re-evaluate automatically when the variable changes.

## Use case (from the issue)

Enables, for example, a single button or a button grid whose preset number comes from a data structure or from `$(cam:presetSelected)` — instead of maintaining a dropdown on each button individually.

## Also included

- **Fix:** Default of the "Action" dropdown changed from `'00'` → `'R'`, so it correctly initializes to "Recall / Play" instead of showing an invalid `?? (00)` (red).
- **Fix:** `useVar: false` set explicitly in the generated presets, so preset-filled buttons initialize the field visibility correctly.
- Consistent wording of the visible labels: `"Preset Nr."` → `"Preset #"` (consistent with the existing variable names "Preset # Selected/Completed").

## Compatibility

Fully backward compatible — existing buttons keep their dropdown (`useVar` defaults to `false`), no upgrade script required.

## Testing

- `yarn lint` passes cleanly; both changed ESM modules import without error.
- To verify manually in Companion: toggling the checkbox swaps the dropdown/variable field correctly; variable `5` → wire command `R04`/`M04`/`C04`, and the feedback matches preset 5; out-of-range values are clamped, invalid values trigger no action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)