### PR TITLE
Address the v2.0.0 module review (release 2.0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-.vscode/
-.yarn/
 node_modules/
+package-lock.json
 /pkg
 /pkg.tgz
-.vscode/
+/*.tgz
 DEBUG-*
+/.yarn
+
+.vscode/
 *.log
-*.tgz

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Bitfocus AS
+Copyright (c) 2022 Bitfocus AS - Open Source
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -73,5 +73,5 @@
 		"AJ-CX4000",
 		"AJ-UPX900"
 	],
-	"keywords": ["Camera", "PTZ", "AW", "AJ", "AG", "AK", "CX", "UPX", "UB", "UE", "UN", "UR", "HE", "HN", "HR", "Panasonic"]
+	"keywords": ["Camera", "PTZ", "AW", "AJ", "AG", "AK", "CX", "UPX", "UB", "UE", "UN", "UR", "HE", "HN", "HR"]
 }

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -5,7 +5,7 @@
 	"name": "panasonic-cameras",
 	"shortname": "Cameras",
 	"description": "Companion module for Panasonic's IP remote controllable cameras. It supports all AW series PTZ cameras as well as other box camera and camcorder models which use the same remote control protocol.",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-panasonic-cameras.git",
 	"bugs": "https://github.com/bitfocus/companion-module-panasonic-cameras/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "panasonic-cameras",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"main": "src/index.js",
 	"type": "module",
 	"scripts": {

--- a/src/__tests__/definitions.test.js
+++ b/src/__tests__/definitions.test.js
@@ -44,6 +44,34 @@ function seriesSpec(series) {
 	return SERIES_SPECS.find((s) => s.id === series)
 }
 
+// A level capability drives optSetIncDecStep() and cmdValue(): `step` becomes the Step size field's
+// default *and* its min, `hexlen` the width of the value on the wire. Miss either and the field ships
+// with `default: undefined`, fillOmittedOptions skips it (it only fills ids that have a default), and
+// resolveSetStep() gets parseInt(undefined) -> NaN, so the action returns having sent nothing. That is
+// how the AK-UB300's Master Pedestal shipped as a silent no-op.
+describe('level capabilities', () => {
+	const LEVELS = SERIES_SPECS.flatMap((spec) =>
+		Object.entries(spec.capabilities)
+			.filter(([, cap]) => cap && typeof cap === 'object' && 'offset' in cap && 'limit' in cap)
+			.map(([name, cap]) => ({ series: spec.id, name, cap })),
+	)
+
+	it('is a set worth checking', () => {
+		expect(LEVELS.length).toBeGreaterThan(0)
+	})
+
+	it.each(LEVELS)('$series.$name carries the step and hexlen the action needs', ({ cap }) => {
+		expect(cap.step).toBeTypeOf('number')
+		expect(cap.step).toBeGreaterThan(0)
+		expect(cap.hexlen).toBeTypeOf('number')
+	})
+
+	it.each(LEVELS)('$series.$name declares a hexlen wide enough for its own range', ({ cap }) => {
+		const widest = Math.max(cap.offset + cap.limit, Math.abs(cap.offset - cap.limit))
+		expect(widest.toString(16).length).toBeLessThanOrEqual(cap.hexlen)
+	})
+})
+
 describe.each(MODELS_BY_SERIES)('series $series (via $id)', ({ id, series }) => {
 	const self = mockInstance(id)
 	const caps = seriesSpec(series).capabilities

--- a/src/__tests__/lifecycle.test.js
+++ b/src/__tests__/lifecycle.test.js
@@ -1,7 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as net from 'net'
 import PanasonicCameraInstance, { REACHABILITY_ERRORS, describeError } from '../index.js'
 import { pollCameraStatus } from '../polling.js'
 import { initialData } from '../data.js'
+
+// init_tcp() is the one path that reaches a real socket, so the listener is stubbed. `emitError`
+// stands in for the async 'error' the OS raises after listen() on a taken port.
+vi.mock('net', () => {
+	const createServer = vi.fn(() => {
+		const handlers = {}
+		return {
+			on: vi.fn((event, fn) => (handlers[event] = fn)),
+			listen: vi.fn(),
+			close: vi.fn(),
+			address: () => ({ port: 31004 }),
+			emitError: (err) => handlers.error?.(err),
+		}
+	})
+	return { createServer, default: { createServer } }
+})
 
 // Changing config used to leave the old camera running alongside the new one: it was never
 // unsubscribed (the goodbye went to the new config's host), its open socket survived server.close(),
@@ -309,6 +326,44 @@ describe('handleConnectionError', () => {
 		await self.configUpdated({ ...self.config, host: '10.0.0.2' })
 
 		expect(self.updateStatus.mock.calls.map(([status]) => status)).toEqual(['disconnected'])
+	})
+})
+
+describe('a TCP port that is already taken', () => {
+	beforeEach(() => net.createServer.mockClear())
+
+	function bindOnTakenPort() {
+		const self = makeInstance()
+		self.init_tcp()
+
+		const server = net.createServer.mock.results[0].value
+		server.emitError(Object.assign(new Error('listen EADDRINUSE'), { code: 'EADDRINUSE' }))
+		return { self, server }
+	}
+
+	it('drops the server it could not bind, so nothing later mistakes it for a subscription', () => {
+		const { self, server } = bindOnTakenPort()
+
+		expect(server.close).toHaveBeenCalled()
+		expect(self.server).toBeUndefined()
+	})
+
+	it('does not say goodbye for a subscription it never made', async () => {
+		// The camera was never told about this port: `connect=start` only goes out once the listener is
+		// up. Both the handler's own unsubscribe and teardown()'s goodbye were stops for nothing.
+		const { self } = bindOnTakenPort()
+
+		expect(stops(self)).toHaveLength(0)
+
+		await self.teardown()
+		expect(stops(self)).toHaveLength(0)
+	})
+
+	it('still reports the port conflict to the operator', () => {
+		const { self } = bindOnTakenPort()
+
+		expect(self.updateStatus).toHaveBeenCalledWith('unknown_error', 'TCP Port in use')
+		expect(self.log.mock.calls.some(([, message]) => message.includes('already in use'))).toBe(true)
 	})
 })
 

--- a/src/__tests__/lifecycle.test.js
+++ b/src/__tests__/lifecycle.test.js
@@ -329,6 +329,58 @@ describe('handleConnectionError', () => {
 	})
 })
 
+// A line the parser chokes on is a module bug. Inside the request's try it arrived at
+// handleConnectionError as a TypeError with no `err.code`, which reported it as a camera fault and
+// left the connection deadened with no retry — while poisoning every line behind it in the dump.
+describe('a response line the parser cannot read', () => {
+	const dump = ['p1', 'MALFORMED', 'OSD:B0:20'].join('\r\n')
+
+	it('costs that one line, not the rest of the bulk dump', async () => {
+		const self = makeInstance()
+		self.httpGet = vi.fn(async () => ({ body: dump, statusCode: 200 }))
+
+		// Stand in for a parser that throws on the middle line of a 400-line camdata dump.
+		const seen = []
+		self.parseSafely = vi.fn((line, parse) => {
+			seen.push(line)
+			if (line !== 'MALFORMED') parse()
+		})
+
+		await self.getCameraStatus()
+
+		expect(seen).toEqual(['p1', 'MALFORMED', 'OSD:B0:20'])
+		expect(self.data.power).toBe('1') // the line before it landed
+	})
+
+	it('is named as a module error if one ever does reach the connection handler', () => {
+		const self = makeInstance()
+
+		// got labels everything it raises, so an error with no `code` cannot have come from the camera.
+		self.handleConnectionError(new TypeError("Cannot read properties of undefined (reading 'replace')"))
+
+		const [status, detail] = self.updateStatus.mock.calls.at(-1)
+		expect(status).toBe('unknown_error')
+		expect(detail).toBe("Module error: Cannot read properties of undefined (reading 'replace')")
+	})
+
+	it('gets logged with the line that produced it', async () => {
+		const self = makeInstance()
+		self.httpGet = vi.fn(async () => ({ body: dump, statusCode: 200 }))
+
+		self.parseSafely = (line, parse) =>
+			PanasonicCameraInstance.prototype.parseSafely.call(self, line, () => {
+				if (line === 'MALFORMED') throw new TypeError('nope')
+				parse()
+			})
+
+		await self.getCameraStatus()
+
+		const logged = self.log.mock.calls.map(([, message]) => message)
+		expect(logged.some((m) => m.includes('Failed to parse camera response "MALFORMED"'))).toBe(true)
+		expect(self.updateStatus.mock.calls.map(([status]) => status)).toEqual(['ok']) // still a healthy camera
+	})
+})
+
 describe('a TCP port that is already taken', () => {
 	beforeEach(() => net.createServer.mockClear())
 

--- a/src/__tests__/lifecycle.test.js
+++ b/src/__tests__/lifecycle.test.js
@@ -56,6 +56,7 @@ function makeInstance(config = {}, { series = 'UE80', capabilities } = {}) {
 	self.pollImageGen = 0
 	self.imageErrors = 0
 	self.failures = 0
+	self.reconnecting = false
 	self.imageSubscribers = new Map()
 	self.tcpPortSelected = 31004
 
@@ -319,6 +320,39 @@ describe('handleConnectionError', () => {
 		expect(self.updateStatus.mock.calls.map(([status]) => status)).toEqual(['connection_failure'])
 	})
 
+	it('does not let a late answer cancel a reconnect that is already committed', async () => {
+		// scheduleReInit() has stopped the poll loops and only reInitAll() starts them again. A request
+		// still in flight when the streak completed would otherwise clear the timer on its way in,
+		// leaving the connection reporting Ok with its monitoring dead for good.
+		const self = makeInstance()
+		self.reInitAll = vi.fn(async () => {})
+		self.poll = true
+
+		for (let i = 0; i < 3; i++) self.handleConnectionError({ code: 'ETIMEDOUT' })
+		expect(self.poll).toBe(false) // committed
+
+		self.httpGet = vi.fn(async () => ({ body: 'OID:AW-UE100\r\n', statusCode: 200 }))
+		await self.getCam('QID') // the in-flight request lands a moment too late
+
+		expect(self.updateStatus.mock.calls.map(([status]) => status)).toEqual(['connection_failure'])
+
+		await vi.advanceTimersByTimeAsync(self.config.timeout + self.config.pollDelay)
+		expect(self.reInitAll).toHaveBeenCalled() // the reconnect still runs, and restarts polling
+	})
+
+	it('takes a rejected request as proof the camera is there', async () => {
+		// ERR_NON_2XX_3XX_RESPONSE means the camera answered, so it ends a streak rather than ignoring it.
+		const self = makeInstance()
+
+		self.handleConnectionError({ code: 'ECONNRESET' })
+		expect(vi.getTimerCount()).toBe(1)
+
+		self.handleConnectionError({ code: 'ERR_NON_2XX_3XX_RESPONSE' })
+
+		expect(self.failures).toBe(0)
+		expect(vi.getTimerCount()).toBe(0)
+	})
+
 	it('keeps Disconnected for the one thing the user did on purpose', async () => {
 		const self = makeInstance()
 		self.reInitAll = vi.fn()
@@ -409,6 +443,34 @@ describe('a TCP port that is already taken', () => {
 
 		await self.teardown()
 		expect(stops(self)).toHaveLength(0)
+	})
+
+	it('lets a pushed update prove the camera is still there', async () => {
+		// A subscription-only camera can go minutes without an HTTP request, so one failed request
+		// would otherwise sit at failures > 0 until the fallback declared a connection lost that had
+		// been pushing updates the whole time.
+		vi.useFakeTimers()
+		const self = makeInstance()
+		self.init_tcp()
+
+		self.handleConnectionError({ code: 'ECONNRESET' })
+		expect(self.failures).toBe(1)
+		expect(vi.getTimerCount()).toBe(1)
+
+		// Frame layout per Interface Specifications §4.2: [Reserve 22][Size 2][Reserve 4][CRLF cmd CRLF][Reserve 24]
+		const info = Buffer.concat([Buffer.from('\r\n'), Buffer.from('p1', 'latin1'), Buffer.from('\r\n')])
+		const header = Buffer.alloc(28, 0x01)
+		header.writeUInt16BE(info.length + 8, 22)
+
+		const socket = { ...fakeSocket(), on: vi.fn() }
+		net.createServer.mock.calls[0][0](socket)
+		const onData = socket.on.mock.calls.find(([event]) => event === 'data')[1]
+		onData(Buffer.concat([header, info, Buffer.alloc(24, 0x02)]))
+
+		expect(self.data.power).toBe('1') // the batch really was parsed
+		expect(self.failures).toBe(0)
+		expect(vi.getTimerCount()).toBe(0)
+		vi.useRealTimers()
 	})
 
 	it('still reports the port conflict to the operator', () => {

--- a/src/__tests__/lifecycle.test.js
+++ b/src/__tests__/lifecycle.test.js
@@ -38,6 +38,7 @@ function makeInstance(config = {}, { series = 'UE80', capabilities } = {}) {
 	self.pollImage = false
 	self.pollImageGen = 0
 	self.imageErrors = 0
+	self.failures = 0
 	self.imageSubscribers = new Map()
 	self.tcpPortSelected = 31004
 
@@ -200,6 +201,9 @@ describe('handleConnectionError', () => {
 	it.each([...REACHABILITY_ERRORS])('reports %s as a connection failure, and keeps trying', (code) => {
 		const self = makeInstance()
 
+		// One of these is a blip; a streak of them is a lost camera (see FAILURE_THRESHOLD).
+		self.handleConnectionError({ code })
+		self.handleConnectionError({ code })
 		expect(self.handleConnectionError({ code })).toBe(true)
 
 		expect(self.updateStatus.mock.calls.map(([status]) => status)).toEqual(['connection_failure'])
@@ -254,6 +258,48 @@ describe('handleConnectionError', () => {
 		self.handleConnectionError({ code: 'EHOSTUNREACH' })
 
 		expect(vi.getTimerCount()).toBe(1)
+	})
+
+	it('rides out a single dropped connection instead of rebuilding the whole instance', async () => {
+		// ECONNRESET on a keep-alive is routine with these cameras. Read as a lost connection it stopped
+		// polling, flipped the status and re-published ~200 presets — a full panel redraw for a blip.
+		const self = makeInstance()
+		self.poll = true
+
+		expect(self.handleConnectionError({ code: 'ECONNRESET' })).toBe(false) // not worth logging yet
+
+		expect(self.updateStatus).not.toHaveBeenCalled()
+		expect(self.poll).toBe(true) // polling is what recovers it
+	})
+
+	it('withdraws the pending retry as soon as a request gets through again', async () => {
+		const self = makeInstance()
+		self.reInitAll = vi.fn()
+		self.httpGet = vi.fn(async () => ({ body: 'OID:AW-UE100\r\n', statusCode: 200 }))
+
+		self.handleConnectionError({ code: 'ECONNRESET' })
+		expect(vi.getTimerCount()).toBe(1) // armed in case nothing else drives a retry
+
+		await self.getCam('QID') // the very next poll succeeds
+
+		expect(vi.getTimerCount()).toBe(0)
+		expect(self.updateStatus.mock.calls.map(([status]) => status)).toEqual(['ok'])
+
+		// Nothing must resurrect the reconnect once the connection has proven itself.
+		await vi.advanceTimersByTimeAsync(60_000)
+		expect(self.reInitAll).not.toHaveBeenCalled()
+	})
+
+	it('still gives up on a camera that goes quiet without another request to notice', async () => {
+		// A subscription-only camera makes no further requests, so the streak can never grow past one.
+		// The fallback timer is what keeps that connection from sitting in Ok forever.
+		const self = makeInstance()
+		self.reInitAll = vi.fn()
+
+		self.handleConnectionError({ code: 'EHOSTUNREACH' })
+		await vi.advanceTimersByTimeAsync(self.config.timeout + self.config.pollDelay)
+
+		expect(self.updateStatus.mock.calls.map(([status]) => status)).toEqual(['connection_failure'])
 	})
 
 	it('keeps Disconnected for the one thing the user did on purpose', async () => {

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parseUpdate } from '../parser.js'
-import { constrainRange, getNext, getNextValue, getLabel, toHexString } from '../common.js'
+import { constrainRange, getNext, getNextValue, getLabel, seriesOf, toHexString } from '../common.js'
 
 // parseUpdate mutates self.data in place from the camera's notification strings.
 function parse(...args) {
@@ -84,6 +84,26 @@ describe('parseUpdate', () => {
 
 		expect(self.data.zoomSpeedValue).toBe(7)
 		expect(self.data.focusSpeedValue).toBe(7)
+	})
+})
+
+// checkVariables() runs after every HTTP response and every TCP batch. Resolving the series there
+// meant two Array.find scans over the model tables, plus a write to self.data, on that hot path.
+describe('seriesOf', () => {
+	const bare = (model) => ({ config: { model }, data: { model: null, modelAuto: null, series: null } })
+
+	it('hands back what the connection already resolved instead of scanning again', () => {
+		const resolved = { id: 'UE160', capabilities: {} }
+		const self = { ...bare('AW-HE2'), SERIES: resolved }
+
+		expect(seriesOf(self)).toBe(resolved)
+		expect(self.data.model).toBeNull() // the hot path writes nothing
+	})
+
+	it('still resolves for a caller with no connection behind it', () => {
+		// The upgrade scripts and the definition tests build a bare self; so does reInitAll() until the
+		// camera has answered QID.
+		expect(seriesOf(bare('AW-HE2')).capabilities.preset).toBe(9)
 	})
 })
 

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -64,6 +64,27 @@ describe('parseUpdate', () => {
 		expect(parse('zS50').zoomSpeedValue).toBe(0)
 		expect(parse('fS99').focusSpeedValue).toBe(49)
 	})
+
+	// NaN publishes as a NaN variable, satisfies the zoomControl feedback (NaN != 0) so the button
+	// latches lit, and comes back out of lensAxis as a literal "#ZNaN" on the wire.
+	it.each(['zS', 'zSx', 'zS-', 'fS', 'fSab'])('keeps the last known speed rather than storing NaN for %s', (cmd) => {
+		const self = {
+			data: {
+				zoomSpeedValue: 7,
+				focusSpeedValue: 7,
+				presetThumbnails: [],
+				presetEntries: [],
+				presetEntries0: [],
+				presetEntries1: [],
+				presetEntries2: [],
+			},
+			getThumbnail: () => {},
+		}
+		parseUpdate(self, [cmd])
+
+		expect(self.data.zoomSpeedValue).toBe(7)
+		expect(self.data.focusSpeedValue).toBe(7)
+	})
 })
 
 describe('common helpers', () => {

--- a/src/__tests__/upgrades.test.js
+++ b/src/__tests__/upgrades.test.js
@@ -20,9 +20,10 @@ const expr = (value) => ({ isExpression: true, value })
 // A preset-built button that stored only the operation, leaving the hidden value unset.
 const brokenPowerButton = () => ({ actionId: 'power', options: { op: val('t') } })
 
-const run = (props) => fillOmittedOptions({}, { config: { model: 'AW-UE100' }, feedbacks: [], ...props })
-const migrate = (props) =>
-	dropUseVarToggles({}, { config: { model: 'AW-UE100' }, actions: [], feedbacks: [], ...props })
+const run = (props, context = {}) =>
+	fillOmittedOptions(context, { config: { model: 'AW-UE100' }, feedbacks: [], ...props })
+const migrate = (props, context = {}) =>
+	dropUseVarToggles(context, { config: { model: 'AW-UE100' }, actions: [], feedbacks: [], ...props })
 
 // Scripts are identified by index, so one may only ever be appended — a removed or reordered script
 // re-runs the wrong migration on every existing connection.
@@ -124,6 +125,21 @@ describe('fillOmittedOptions', () => {
 
 		expect(() => run({ config, actions })).not.toThrow()
 	})
+
+	// props.config is only filled when the connection itself is upgraded; upgrading buttons hands it
+	// over as null. Reading the model off it reconciled a UE160's buttons against the generic `Other`
+	// action set, so a filled default could be a value the real model's choices do not contain.
+	it('takes the model from the context when props.config is null', () => {
+		const actions = [{ actionId: 'gain', options: { op: val('s') } }]
+		run({ config: null, actions }, { currentConfig: { model: 'AK-UB300' } })
+
+		const field = getActionDefinitions({
+			config: { model: 'AK-UB300' },
+			data: { model: null, modelAuto: null, series: null, presetThumbnails: [] },
+		}).gain.options.find((o) => o.id === 'set')
+
+		expect(field.choices.map((c) => c.id)).toContain(actions[0].options.set.value)
+	})
 })
 
 // The "Use Variable" checkbox and its parallel textinputs are gone (every field is expression-capable
@@ -195,6 +211,15 @@ describe('dropUseVarToggles', () => {
 		it('clamps a literal to a slot this model actually has', () => {
 			const actions = [{ actionId: 'presetMem', options: { useVar: val(true), valVar: val('150') } }]
 			migrate({ config: { model: 'AW-HE2' }, actions }) // the one camera with only nine slots
+
+			expect(actions[0].options.val).toEqual(val('08'))
+		})
+
+		it('clamps against the context model when props.config is null', () => {
+			// Off props.config alone the count fell back to 100, so an AW-HE2 clamped to '99' — a slot
+			// the camera does not have — instead of '08'.
+			const actions = [{ actionId: 'presetMem', options: { useVar: val(true), valVar: val('150') } }]
+			migrate({ config: null, actions }, { currentConfig: { model: 'AW-HE2' } })
 
 			expect(actions[0].options.val).toEqual(val('08'))
 		})

--- a/src/__tests__/upgrades.test.js
+++ b/src/__tests__/upgrades.test.js
@@ -8,11 +8,17 @@ import { getActionDefinitions } from '../actions.js'
 
 // Pinned by index, not `.at(-1)`: Companion identifies a script by position, so appending one must
 // not repoint these tests at the new arrival.
+const addSetStepSize = upgradeScripts[1]
 const fillOmittedOptions = upgradeScripts[2]
 const dropUseVarToggles = upgradeScripts[3]
 
+// An upgrade script both reads and writes CompanionMigrationOptionValues, so every option in these
+// fixtures — and every option a script writes — is an ExpressionOrValue wrapper, never a bare value.
+const val = (value) => ({ isExpression: false, value })
+const expr = (value) => ({ isExpression: true, value })
+
 // A preset-built button that stored only the operation, leaving the hidden value unset.
-const brokenPowerButton = () => ({ actionId: 'power', options: { op: 't' } })
+const brokenPowerButton = () => ({ actionId: 'power', options: { op: val('t') } })
 
 const run = (props) => fillOmittedOptions({}, { config: { model: 'AW-UE100' }, feedbacks: [], ...props })
 const migrate = (props) =>
@@ -27,13 +33,49 @@ describe('upgradeScripts', () => {
 	})
 })
 
+describe('addSetStepSize', () => {
+	const step = (props) => addSetStepSize({}, { config: { model: 'AW-UE100' }, feedbacks: [], ...props })
+
+	it('gives the speed actions a step size, in the value wrapper 2.0 requires', () => {
+		const actions = [{ actionId: 'zoomSpeed', options: { op: val('i') } }]
+		const result = step({ actions })
+
+		expect(actions[0].options.step).toEqual(val(1))
+		expect(result.updatedActions).toEqual(actions)
+	})
+
+	it('leaves a step size the button already carries alone', () => {
+		const actions = [{ actionId: 'ptSpeed', options: { op: val('i'), step: val(5) } }]
+		step({ actions })
+
+		expect(actions[0].options.step).toEqual(val(5))
+	})
+
+	it('does not touch an action that has no step size', () => {
+		const actions = [{ actionId: 'power', options: { op: val('t') } }]
+		const result = step({ actions })
+
+		expect(actions[0].options).toEqual({ op: val('t') })
+		expect(result.updatedActions).toEqual([])
+	})
+})
+
 describe('fillOmittedOptions', () => {
 	it('gives a value to the options a preset-built button never got', () => {
 		const actions = [brokenPowerButton()]
 		const result = run({ actions })
 
-		expect(actions[0].options).toEqual({ op: 't', set: '0' })
+		expect(actions[0].options).toEqual({ op: val('t'), set: val('0') })
 		expect(result.updatedActions).toEqual(actions)
+	})
+
+	// A bare default reads back as `.value === undefined`, which is the very state — an option
+	// Companion cannot parse, taking the whole action down — that this script exists to repair.
+	it('writes the value wrapper 2.0 requires, not the bare default', () => {
+		const actions = [brokenPowerButton()]
+		run({ actions })
+
+		expect(actions[0].options.set).toEqual({ isExpression: false, value: '0' })
 	})
 
 	it('fills only from the action definition, so the value it writes is one Companion accepts', () => {
@@ -45,14 +87,14 @@ describe('fillOmittedOptions', () => {
 			data: { model: null, modelAuto: null, series: null, presetThumbnails: [] },
 		}).power.options.find((o) => o.id === 'set')
 
-		expect(field.choices.map((c) => c.id)).toContain(actions[0].options.set)
+		expect(field.choices.map((c) => c.id)).toContain(actions[0].options.set.value)
 	})
 
 	it('leaves a value the user picked alone', () => {
-		const actions = [{ actionId: 'gain', options: { op: 's', set: '20' } }]
+		const actions = [{ actionId: 'gain', options: { op: val('s'), set: val('20') } }]
 		const result = run({ actions })
 
-		expect(actions[0].options.set).toBe('20')
+		expect(actions[0].options.set).toEqual(val('20'))
 		expect(result.updatedActions).toEqual([])
 	})
 
@@ -60,7 +102,7 @@ describe('fillOmittedOptions', () => {
 		const feedbacks = [{ feedbackId: 'shootingMode', options: {} }]
 		const result = run({ actions: [], feedbacks })
 
-		expect(feedbacks[0].options).toEqual({ option: '0' })
+		expect(feedbacks[0].options).toEqual({ option: val('0') })
 		expect(result.updatedFeedbacks).toEqual(feedbacks)
 	})
 
@@ -87,10 +129,6 @@ describe('fillOmittedOptions', () => {
 // The "Use Variable" checkbox and its parallel textinputs are gone (every field is expression-capable
 // in 2.0). Where the checkbox was on, the textinput's value must survive as an expression on the plain field.
 describe('dropUseVarToggles', () => {
-	// An upgrade script sees the 2.0 wrapper, so that is the shape these fixtures use.
-	const val = (value) => ({ isExpression: false, value })
-	const expr = (value) => ({ isExpression: true, value })
-
 	describe('with the checkbox on', () => {
 		it('lifts a variable onto the plain field as an expression', () => {
 			const actions = [

--- a/src/__tests__/upgrades.test.js
+++ b/src/__tests__/upgrades.test.js
@@ -11,6 +11,7 @@ import { getActionDefinitions } from '../actions.js'
 const addSetStepSize = upgradeScripts[1]
 const fillOmittedOptions = upgradeScripts[2]
 const dropUseVarToggles = upgradeScripts[3]
+const repairPre201Writes = upgradeScripts[4]
 
 // An upgrade script both reads and writes CompanionMigrationOptionValues, so every option in these
 // fixtures — and every option a script writes — is an ExpressionOrValue wrapper, never a bare value.
@@ -29,8 +30,84 @@ const migrate = (props, context = {}) =>
 // re-runs the wrong migration on every existing connection.
 describe('upgradeScripts', () => {
 	it('only ever grows, and blanks a retired script in place', () => {
-		expect(upgradeScripts).toHaveLength(4)
+		expect(upgradeScripts).toHaveLength(5)
 		expect(upgradeScripts[0]).toBe(EmptyUpgradeScript)
+	})
+})
+
+// v2.0.0 published slots 1 and 2 writing bare values, from a model resolved off a null props.config.
+// Companion never re-runs a completed index, so repairing those slots in place reaches only
+// connections coming straight from 1.x; everyone who ran 2.0.0 needs this appended slot.
+describe('repairPre201Writes', () => {
+	const repair = (props, context = {}) =>
+		repairPre201Writes(context, { config: { model: 'AW-UE100' }, actions: [], feedbacks: [], ...props })
+
+	it('wraps the bare value the published slot 2 wrote', () => {
+		// Bare, Companion reads it as `.value === undefined` and drops the whole action.
+		const actions = [{ actionId: 'power', options: { op: val('t'), set: '0' } }]
+		const result = repair({ actions })
+
+		expect(actions[0].options.set).toEqual(val('0'))
+		expect(result.updatedActions).toEqual(actions)
+	})
+
+	it('wraps the bare step the published slot 1 wrote', () => {
+		const actions = [{ actionId: 'zoomSpeed', options: { op: val('i'), step: 1 } }]
+		repair({ actions })
+
+		expect(actions[0].options.step).toEqual(val(1))
+	})
+
+	it('puts this model back behind a default filled from the wrong one', () => {
+		// Slot 2 built its definitions against `Other`, so the value it filled in can be one the real
+		// model's choices do not contain — and Companion drops the entity over exactly that.
+		const actions = [{ actionId: 'gain', options: { op: val('s'), set: val('not-a-choice') } }]
+		const result = repair({ actions }, { currentConfig: { model: 'AK-UB300' } })
+
+		const field = getActionDefinitions({
+			config: { model: 'AK-UB300' },
+			data: { model: null, modelAuto: null, series: null, presetThumbnails: [] },
+		}).gain.options.find((o) => o.id === 'set')
+
+		expect(field.choices.map((c) => c.id)).toContain(actions[0].options.set.value)
+		expect(result.updatedActions).toEqual(actions)
+	})
+
+	it('brings a preset index back into the range this model has', () => {
+		// Slot 3 clamped against 100 when props.config was null, so an AW-HE2 kept '99'.
+		const actions = [{ actionId: 'presetMem', options: { op: val('R'), val: val('99') } }]
+		repair({ actions }, { currentConfig: { model: 'AW-HE2' } })
+
+		expect(actions[0].options.val).toEqual(val('08'))
+	})
+
+	it('leaves a connection that came straight from 1.x untouched', () => {
+		// The repaired slots above already wrote the right shape from the right model, so there is
+		// nothing here to change and nothing to report as updated.
+		const actions = [brokenPowerButton()]
+		run({ actions })
+		const result = repair({ actions })
+
+		expect(actions[0].options).toEqual({ op: val('t'), set: val('0') })
+		expect(result.updatedActions).toEqual([])
+	})
+
+	it('never rewrites an expression the user wrote', () => {
+		const actions = [{ actionId: 'presetMem', options: { op: val('R'), val: expr('$(local:preset)') } }]
+		const result = repair({ actions }, { currentConfig: { model: 'AW-HE2' } })
+
+		expect(actions[0].options.val).toEqual(expr('$(local:preset)'))
+		expect(result.updatedActions).toEqual([])
+	})
+
+	it.each([
+		['no config at all', null],
+		['a model that is only resolved once a camera answers', { model: 'Auto' }],
+		['a model this module does not know', { model: 'AW-NOT-A-CAMERA' }],
+	])('survives %s', (_name, config) => {
+		const actions = [{ actionId: 'power', options: { set: '0' } }, { actionId: 'power' }]
+
+		expect(() => repair({ config, actions })).not.toThrow()
 	})
 })
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,6 @@
 import { e } from './enum.js'
 import {
-	getAndUpdateSeries,
+	seriesOf,
 	getNext,
 	getNextValue,
 	constrainRange,
@@ -257,7 +257,7 @@ function cmdSpeed(speed) {
 export function getActionDefinitions(self) {
 	const actions = {}
 
-	const SERIES = getAndUpdateSeries(self)
+	const SERIES = seriesOf(self)
 	const caps = SERIES.capabilities
 
 	const cam = (cmd) => self.getCam(cmd)

--- a/src/actions.js
+++ b/src/actions.js
@@ -211,15 +211,26 @@ function optSetLowerRaise(label = 'Speed', def, min, max, step = 1) {
 // #### Command formatting ####
 // ############################
 
+// Aborting sends no command. Silently, that is indistinguishable from a dead button — which is how
+// the AK-UB300's Master Pedestal shipped: its capability carried no `step`, so the field's default
+// and min were undefined and every Increase/Decrease returned here without a trace.
+function abortSetStep(self, action, field) {
+	self.log(
+		'warn',
+		`${action.actionId}: no command sent, "${field}" did not resolve to a number (${action.options[field]})`,
+	)
+	return false
+}
+
 // Constrains set/step into range; returns false on a non-numeric value to abort the action.
-function resolveSetStep(action, min, max, step) {
+function resolveSetStep(self, action, min, max, step) {
 	if (action.options.op === ACTION_SET) {
 		const set = constrainRange(parseInt(action.options.set, 10), min, max)
-		if (isNaN(set)) return false
+		if (isNaN(set)) return abortSetStep(self, action, 'set')
 		action.options.set = set
 	} else {
 		const size = constrainRange(parseInt(action.options.step, 10), step, max - min)
-		if (isNaN(size)) return false
+		if (isNaN(size)) return abortSetStep(self, action, 'step')
 		action.options.step = size
 	}
 	return true
@@ -268,7 +279,7 @@ export function getActionDefinitions(self) {
 		name,
 		options: optSetIncDecStep(label, 0, -level.limit, +level.limit, level.step),
 		callback: async (action) => {
-			if (!resolveSetStep(action, -level.limit, level.limit, level.step)) return
+			if (!resolveSetStep(self, action, -level.limit, level.limit, level.step)) return
 			const value = cmdValue(action, level.offset, -level.limit, level.limit, action.options.step, level.hexlen, read())
 			await cam(`${command}:${value}`)
 		},
@@ -409,7 +420,7 @@ export function getActionDefinitions(self) {
 				...optSetLowerRaise('Speed', SPEED_DEFAULT, SPEED_MIN, SPEED_MAX, 1),
 			],
 			callback: async (action) => {
-				if (!resolveSetStep(action, SPEED_MIN, SPEED_MAX, 1)) return
+				if (!resolveSetStep(self, action, SPEED_MIN, SPEED_MAX, 1)) return
 				switch (action.options.scope) {
 					case 'pt':
 						self.ptSpeed =
@@ -464,7 +475,7 @@ export function getActionDefinitions(self) {
 			name: 'Lens - Follow Focus',
 			options: optSetIncDecStep('Focus setting', 0x555, 0x0, 0xaaa, 10),
 			callback: async (action) => {
-				if (!resolveSetStep(action, 0x0, 0xaaa, 10)) return
+				if (!resolveSetStep(self, action, 0x0, 0xaaa, 10)) return
 				await ptz('AXF' + cmdValue(action, 0x555, 0x0, 0xaaa, action.options.step, 3, self.data.focusPosition))
 			},
 		}
@@ -496,7 +507,7 @@ export function getActionDefinitions(self) {
 						name: 'Exposure - Iris',
 						options: optSetIncDecStep('Iris setting', 0x1ff, 0x0, 0x3ff, 0xa),
 						callback: async (action) => {
-							if (!resolveSetStep(action, 0x0, 0x3ff, 0xa)) return
+							if (!resolveSetStep(self, action, 0x0, 0x3ff, 0xa)) return
 							await cam('ORV:' + cmdValue(action, 0x0, 0x0, 0x3ff, action.options.step, 3, self.data.irisVolume))
 						},
 					}
@@ -504,7 +515,7 @@ export function getActionDefinitions(self) {
 						name: 'Exposure - Iris',
 						options: optSetIncDecStep('Iris setting', 0x555, 0x0, 0xaaa, 0x1e),
 						callback: async (action) => {
-							if (!resolveSetStep(action, 0x0, 0xaaa, 0x1e)) return
+							if (!resolveSetStep(self, action, 0x0, 0xaaa, 0x1e)) return
 							await ptz('AXI' + cmdValue(action, 0x555, 0x0, 0xaaa, action.options.step, 3, self.data.irisPosition))
 						},
 					}
@@ -663,7 +674,7 @@ export function getActionDefinitions(self) {
 				? optSetIncDecStep('Color Temperature [K]', 3200, advanced.min, advanced.max, 20)
 				: optIncDec(),
 			callback: async (action) => {
-				if (advanced.set && !resolveSetStep(action, advanced.min, advanced.max, 20)) return
+				if (advanced.set && !resolveSetStep(self, action, advanced.min, advanced.max, 20)) return
 				switch (action.options.op) {
 					case ACTION_SET:
 						await cam(advanced.set + ':' + toHexString(action.options.set, 5) + ':0')
@@ -862,7 +873,7 @@ export function getActionDefinitions(self) {
 				...optSetIncDecStep('Volume Level (dB)', 0, audio.min, audio.max, audio.step),
 			],
 			callback: async (action) => {
-				if (!resolveSetStep(action, audio.min, audio.max, audio.step)) return
+				if (!resolveSetStep(self, action, audio.min, audio.max, audio.step)) return
 				const value = cmdValue(
 					action,
 					0x80,

--- a/src/common.js
+++ b/src/common.js
@@ -21,6 +21,14 @@ export function getAndUpdateSeries(self) {
 	return SERIES || SERIES_SPECS.find((SERIES_SPECS) => SERIES_SPECS.id === 'Other')
 }
 
+// The series a running instance is on. reInitAll() resolves it once per connection; everything else
+// reads that. The fallback is for callers with no live instance behind them — the upgrade scripts and
+// the definition tests build a bare `self` — and for the window inside reInitAll() before the QID
+// answer has been turned into a series.
+export function seriesOf(self) {
+	return self.SERIES ?? getAndUpdateSeries(self)
+}
+
 export function getNext(values, key, step = 1, overrun = true) {
 	const firstIndex = 0
 	const lastIndex = values.length - 1

--- a/src/common.js
+++ b/src/common.js
@@ -128,6 +128,7 @@ export function optionSpecs(definitions) {
 				id,
 				{
 					ids: fields.map((field) => field.id),
+					fields: Object.fromEntries(fields.map((field) => [field.id, field])),
 					defaults: Object.fromEntries(
 						fields.filter((field) => field.default !== undefined).map((field) => [field.id, field.default]),
 					),

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -185,7 +185,7 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.zoomControl = stateFeedback(
 			'Lens - Zoom Control',
 			'Indicates if Zoom is currently in operation',
-			() => self.data.zoomSpeedValue != 0,
+			() => Number(self.data.zoomSpeedValue) !== 0,
 		)
 	}
 

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -1,5 +1,5 @@
 import { combineRgb } from '@companion-module/base'
-import { getAndUpdateSeries, optPresetNumber, parsePresetNumber } from './common.js'
+import { seriesOf, optPresetNumber, parsePresetNumber } from './common.js'
 import { startLiveImagePoll } from './polling.js'
 import { e } from './enum.js'
 import ICONS from './icons.js'
@@ -69,7 +69,7 @@ function parsePresetIdx(feedback, max) {
 export function getFeedbackDefinitions(self) {
 	const feedbacks = {}
 
-	const SERIES = getAndUpdateSeries(self)
+	const SERIES = seriesOf(self)
 	const caps = SERIES.capabilities
 
 	// ---- System ----

--- a/src/index.js
+++ b/src/index.js
@@ -617,6 +617,10 @@ export default class PanasonicCameraInstance extends InstanceBase {
 		await this.teardown()
 		const generation = this.generation
 
+		// The one place the series is resolved. Cleared first so the QID round-trip below — which
+		// publishes variables on its way through — cannot read the previous camera's capabilities.
+		this.SERIES = undefined
+
 		this.imageErrors = 0
 		this.failures = 0 // the streak belonged to the connection just torn down
 		this.updateStatus(InstanceStatus.Connecting, this.config.host + ':' + this.config.httpPort)

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,18 @@ export default class PanasonicCameraInstance extends InstanceBase {
 		return generation === this.generation
 	}
 
+	// One camera line is one parse. Contained here, a line the parser chokes on costs that line and
+	// not the 390 behind it in a bulk dump — and, more importantly, never leaves the parse inside the
+	// request's try, where a TypeError carrying no `err.code` reached handleConnectionError and was
+	// reported to the operator as a camera fault, with the connection deadened and no retry armed.
+	parseSafely(line, parse) {
+		try {
+			parse()
+		} catch (err) {
+			this.log('error', `Failed to parse camera response "${line}": ${describeError(err)}`)
+		}
+	}
+
 	// All requests go through here so teardown()'s abort signal is never missed.
 	httpGet(url, options = {}) {
 		return got.get(url, {
@@ -217,7 +229,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 							this.log('info', `Received Update: ${command}  (${source})`)
 						}
 
-						parseUpdate(this, command.split(':'))
+						this.parseSafely(command, () => parseUpdate(this, command.split(':')))
 					}
 
 					// Once for the whole batch: a coalesced burst is one redraw.
@@ -292,7 +304,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 							this.log('info', 'camdata response: ' + str)
 						}
 
-						parseUpdate(this, str.split(':'))
+						this.parseSafely(str, () => parseUpdate(this, str.split(':')))
 					}
 
 					this.checkVariables()
@@ -326,7 +338,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 					this.log('info', 'PTZ response: ' + str)
 				}
 
-				parseUpdate(this, str.split(':'))
+				this.parseSafely(str, () => parseUpdate(this, str.split(':')))
 
 				this.checkVariables()
 				this.checkAllFeedbacks()
@@ -358,7 +370,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 					this.log('info', 'Cam response: ' + str)
 				}
 
-				parseUpdate(this, str.split(':'))
+				this.parseSafely(str, () => parseUpdate(this, str.split(':')))
 
 				this.checkVariables()
 				this.checkAllFeedbacks()
@@ -394,14 +406,14 @@ export default class PanasonicCameraInstance extends InstanceBase {
 						this.log('info', 'Web response [' + cmd + ']: ' + str)
 					}
 
-					parseWeb(this, str.split('='), cmd)
+					this.parseSafely(str, () => parseWeb(this, str.split('='), cmd))
 				}
 			} else {
 				if (this.config.debug) {
 					this.log('info', 'Web response [' + cmd + ']: Response code ' + response.statusCode.toString())
 				}
 
-				parseWebCode(this, response.statusCode, cmd)
+				this.parseSafely(response.statusCode, () => parseWebCode(this, response.statusCode, cmd))
 			}
 
 			this.checkVariables()
@@ -561,6 +573,13 @@ export default class PanasonicCameraInstance extends InstanceBase {
 
 		// Camera answered but rejected the request; not a connection problem.
 		if (err.code === 'ERR_NON_2XX_3XX_RESPONSE') return this.config.debug // hide error
+
+		// No code at all is one of ours, not the camera's: got labels everything it raises. Saying so
+		// is the difference between the operator chasing a network fault and reporting a module bug.
+		if (err?.code === undefined) {
+			this.updateStatus(InstanceStatus.UnknownError, 'Module error: ' + describeError(err))
+			return true // print error
+		}
 
 		// Undiagnosed fault: stop rather than retry-loop against it.
 		this.updateStatus(InstanceStatus.UnknownError, describeError(err))

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,9 @@ export default class PanasonicCameraInstance extends InstanceBase {
 
 		// Consecutive reachability failures; a success resets it (see onRequestSucceeded()).
 		this.failures = 0
+
+		// True from the moment a reconnect is committed until it starts, so nothing withdraws it.
+		this.reconnecting = false
 	}
 
 	// True while `generation` is still the running connection.
@@ -110,6 +113,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 		this.pollGen++
 		this.pollImageGen++
 		this.timeoutID = clearTimeout(this.timeoutID) // a retry owed to the old connection is not the new one's
+		this.reconnecting = false // ...and neither is the reconnect that retry was committed to
 
 		// 2. Invalidate in-flight work (see current()) and cancel it so it drops the old camera's socket.
 		this.generation++
@@ -234,6 +238,11 @@ export default class PanasonicCameraInstance extends InstanceBase {
 
 					// Once for the whole batch: a coalesced burst is one redraw.
 					if (updates.length) {
+						// A subscription-only camera may make no HTTP requests for minutes, so without this
+						// one failed request would sit at failures > 0 until the fallback declared a
+						// connection lost that has been pushing updates the whole time.
+						this.markReachable()
+
 						this.checkVariables()
 						this.checkAllFeedbacks()
 					}
@@ -541,13 +550,26 @@ export default class PanasonicCameraInstance extends InstanceBase {
 		await this.reInitAll()
 	}
 
+	// Evidence the camera is reachable, from anything short of a completed request: an HTTP error the
+	// camera itself produced, or a framed batch arriving over the subscription. Ends the failure
+	// streak and withdraws the fallback retry armed for it, but says nothing about the status.
+	//
+	// Refuses once a reconnect is committed: scheduleReInit() has already stopped the poll loops and
+	// only reInitAll() starts them again, so cancelling its timer here would leave the connection
+	// reporting Ok with its monitoring permanently dead. Returns whether it took effect.
+	markReachable() {
+		if (this.reconnecting) return false
+
+		this.failures = 0
+		this.timeoutID = clearTimeout(this.timeoutID)
+		return true
+	}
+
 	// Every request that reached the camera ends here: the connection is up, so the failure streak is
 	// over and any retry owed to it is withdrawn. Without this a single dropped keep-alive left a
 	// re-init armed that fired minutes later against a connection that had long since recovered.
 	onRequestSucceeded() {
-		this.failures = 0
-		this.timeoutID = clearTimeout(this.timeoutID)
-		this.updateStatus(InstanceStatus.Ok)
+		if (this.markReachable()) this.updateStatus(InstanceStatus.Ok)
 	}
 
 	// Handle timeouts and hide HTTP errors. Returns whether the caller should log the error.
@@ -571,8 +593,12 @@ export default class PanasonicCameraInstance extends InstanceBase {
 			return this.config.debug // hide error
 		}
 
-		// Camera answered but rejected the request; not a connection problem.
-		if (err.code === 'ERR_NON_2XX_3XX_RESPONSE') return this.config.debug // hide error
+		// Camera answered but rejected the request; not a connection problem — and an answer is proof
+		// the camera is there, so it ends any streak a reachability error had started.
+		if (err.code === 'ERR_NON_2XX_3XX_RESPONSE') {
+			this.markReachable()
+			return this.config.debug // hide error
+		}
 
 		// No code at all is one of ours, not the camera's: got labels everything it raises. Saying so
 		// is the difference between the operator chasing a network fault and reporting a module bug.
@@ -598,13 +624,17 @@ export default class PanasonicCameraInstance extends InstanceBase {
 	}
 
 	// The instance's one retry timer: a burst of failures must schedule a single re-init, not one each.
+	// Past this point the reconnect is committed — the poll loops are down and nothing but reInitAll()
+	// brings them back, so no late arrival may cancel it (see markReachable()).
 	scheduleReInit(reason) {
+		this.reconnecting = true
 		this.poll = false
 		this.pollImage = false // an unreachable camera must not keep being asked for JPEGs
 		this.updateStatus(InstanceStatus.ConnectionFailure, reason)
 
 		this.timeoutID = clearTimeout(this.timeoutID)
 		this.timeoutID = setTimeout(() => {
+			this.reconnecting = false
 			this.reInitAll().catch((err) => this.log('error', 'Re-initialisation failed: ' + String(err)))
 		}, this.config.timeout + this.config.pollDelay)
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,11 @@ export default class PanasonicCameraInstance extends InstanceBase {
 					this.log('error', 'TCP error: Please change it and click apply in ALL camera instances')
 					this.updateStatus(InstanceStatus.UnknownError, 'TCP Port in use')
 
-					this.unsubscribeTCPEvents(tcpPortSelected).catch(() => null)
+					// Nothing was ever subscribed on this port, so there is nothing to say goodbye to. The
+					// server must still go: teardown() reads `this.server` as proof of a subscription and
+					// would send a stop for a port the camera was never told about.
+					this.server.close()
+					delete this.server
 				} else {
 					this.log('error', 'TCP server error: ' + String(err))
 				}

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,12 @@ export const REACHABILITY_ERRORS = new Set([
 	'EAI_AGAIN', // DNS is temporarily unreachable
 ])
 
+// Consecutive reachability failures before the connection counts as lost. A single dropped
+// connection is routine with these cameras, and declaring it lost is expensive: a full reInitAll()
+// re-queries the model, rebuilds the TCP subscription and re-publishes every action, feedback,
+// variable and preset, so the operator watches the whole panel redraw for a blip already recovered.
+const FAILURE_THRESHOLD = 3
+
 // Lead with the code: got carries it in `code` and does not always repeat it in the message. The
 // String() fallback keeps a thrown non-Error from reading as "[object Object]".
 export function describeError(err) {
@@ -65,6 +71,9 @@ export default class PanasonicCameraInstance extends InstanceBase {
 		this.pollGen = 0
 		this.pollImage = false
 		this.pollImageGen = 0
+
+		// Consecutive reachability failures; a success resets it (see onRequestSucceeded()).
+		this.failures = 0
 	}
 
 	// True while `generation` is still the running connection.
@@ -150,7 +159,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 
 			this.log('info', 'subscribed: ' + url)
 
-			this.updateStatus(InstanceStatus.Ok)
+			this.onRequestSucceeded()
 
 			await this.getPTZ('LPC1') // enable Lens Position Information updates
 		} catch (err) {
@@ -285,7 +294,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 					this.checkVariables()
 					this.checkAllFeedbacks()
 
-					this.updateStatus(InstanceStatus.Ok)
+					this.onRequestSucceeded()
 				}
 			} catch (err) {
 				// The old camera's failure must not schedule a reconnect for the current one.
@@ -318,7 +327,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 				this.checkVariables()
 				this.checkAllFeedbacks()
 
-				this.updateStatus(InstanceStatus.Ok)
+				this.onRequestSucceeded()
 			}
 		} catch (err) {
 			if (!this.current(generation)) return
@@ -350,7 +359,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 				this.checkVariables()
 				this.checkAllFeedbacks()
 
-				this.updateStatus(InstanceStatus.Ok)
+				this.onRequestSucceeded()
 			}
 		} catch (err) {
 			if (!this.current(generation)) return
@@ -394,7 +403,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 			this.checkVariables()
 			this.checkAllFeedbacks()
 
-			this.updateStatus(InstanceStatus.Ok)
+			this.onRequestSucceeded()
 		} catch (err) {
 			if (!this.current(generation)) return
 			if (this.handleConnectionError(err)) this.log('error', 'Web request ' + url + ' failed: ' + String(err))
@@ -425,7 +434,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 
 				this.checkAllFeedbacks()
 
-				this.updateStatus(InstanceStatus.Ok)
+				this.onRequestSucceeded()
 			} catch (err) {
 				if (!this.current(generation)) return
 				if (err.code !== 'ERR_ABORTED') this.log('error', 'Thumbnail request ' + url + ' failed: ' + String(err))
@@ -516,15 +525,34 @@ export default class PanasonicCameraInstance extends InstanceBase {
 		await this.reInitAll()
 	}
 
+	// Every request that reached the camera ends here: the connection is up, so the failure streak is
+	// over and any retry owed to it is withdrawn. Without this a single dropped keep-alive left a
+	// re-init armed that fired minutes later against a connection that had long since recovered.
+	onRequestSucceeded() {
+		this.failures = 0
+		this.timeoutID = clearTimeout(this.timeoutID)
+		this.updateStatus(InstanceStatus.Ok)
+	}
+
 	// Handle timeouts and hide HTTP errors. Returns whether the caller should log the error.
 	handleConnectionError(err) {
 		// Cancelled by teardown(), not a camera failure; got raises it as ERR_ABORTED.
 		if (err.code === 'ERR_ABORTED') return false
 
-		// Unreachable: keep re-initialising until it comes back.
+		// Unreachable: keep re-initialising until it comes back, but only once it is more than a blip.
 		if (REACHABILITY_ERRORS.has(err.code)) {
-			this.scheduleReInit(String(err.code))
-			return true // print error
+			this.failures++
+
+			if (this.failures >= FAILURE_THRESHOLD) {
+				this.scheduleReInit(String(err.code))
+				return true // print error
+			}
+
+			// Not yet evidence the camera is gone. The next request decides — but a connection with no
+			// polling has no next request, so arm a fallback that re-checks once the streak has had time
+			// to either clear itself or grow.
+			this.armFallbackRetry(String(err.code))
+			return this.config.debug // hide error
 		}
 
 		// Camera answered but rejected the request; not a connection problem.
@@ -533,6 +561,17 @@ export default class PanasonicCameraInstance extends InstanceBase {
 		// Undiagnosed fault: stop rather than retry-loop against it.
 		this.updateStatus(InstanceStatus.UnknownError, describeError(err))
 		return true // print error
+	}
+
+	// Sub-threshold failures leave the connection alone but must not leave it unattended: if nothing
+	// drives another request, this is what eventually notices the camera never came back.
+	armFallbackRetry(reason) {
+		if (this.timeoutID) return // one failure already armed it; a success clears it
+
+		this.timeoutID = setTimeout(() => {
+			this.timeoutID = undefined
+			if (this.failures > 0) this.scheduleReInit(reason)
+		}, this.config.timeout + this.config.pollDelay)
 	}
 
 	// The instance's one retry timer: a burst of failures must schedule a single re-init, not one each.
@@ -556,6 +595,7 @@ export default class PanasonicCameraInstance extends InstanceBase {
 		const generation = this.generation
 
 		this.imageErrors = 0
+		this.failures = 0 // the streak belonged to the connection just torn down
 		this.updateStatus(InstanceStatus.Connecting, this.config.host + ':' + this.config.httpPort)
 
 		await this.getCam('QID') // pull model

--- a/src/models.js
+++ b/src/models.js
@@ -411,7 +411,7 @@ export const SERIES_SPECS = [
 			night: false,
 			ois: false,
 			panTilt: false,
-			pedestal: { cmd: 'OSG:4A', offset: 0x80, limit: 99 },
+			pedestal: { cmd: 'OSG:4A', offset: 0x80, limit: 99, step: 1, hexlen: 2 },
 			preset: false,
 			presetSpeed: false,
 			presetTime: false,

--- a/src/parser.js
+++ b/src/parser.js
@@ -139,12 +139,17 @@ export function parseUpdate(self, str) {
 		self.data.presetSpeed = str[0].substring(4)
 	}
 
+	// A short or non-numeric notification would otherwise store NaN, which publishes as a NaN
+	// variable, satisfies the "is the lens moving" feedback (NaN != 0) so the button latches lit, and
+	// feeds back out as a literal "#ZNaN" on the wire. Keep the last known speed instead.
 	if (str[0].substring(0, 2) === 'fS') {
-		self.data.focusSpeedValue = parseInt(str[0].substring(2, 4)) - 50
+		const speed = parseInt(str[0].substring(2, 4), 10)
+		if (Number.isFinite(speed)) self.data.focusSpeedValue = speed - 50
 	}
 
 	if (str[0].substring(0, 2) === 'zS') {
-		self.data.zoomSpeedValue = parseInt(str[0].substring(2, 4)) - 50
+		const speed = parseInt(str[0].substring(2, 4), 10)
+		if (Number.isFinite(speed)) self.data.zoomSpeedValue = speed - 50
 	}
 
 	switch (str[0]) {

--- a/src/presets.js
+++ b/src/presets.js
@@ -1,7 +1,7 @@
 import { combineRgb } from '@companion-module/base'
 import { getActionDefinitions } from './actions.js'
 import { getFeedbackDefinitions } from './feedbacks.js'
-import { getAndUpdateSeries, optionSpecs } from './common.js'
+import { seriesOf, optionSpecs } from './common.js'
 import ICONS from './icons.js'
 import { e } from './enum.js'
 
@@ -175,7 +175,7 @@ const valuePreset = (category, name, text, actionId, feedbackId, value, style) =
 export function getPresetDefinitions(self) {
 	const presets = {}
 
-	const SERIES = getAndUpdateSeries(self)
+	const SERIES = seriesOf(self)
 
 	// ##########################
 	// #### Pan/Tilt Presets ####

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -12,10 +12,16 @@ const DEAD_OPTIONS = ['useVar', 'setVar', 'stepVar', 'valVar', 'optionVar']
 // scripts exist to repair. Everything written to an entity's options goes through here.
 const wrap = (value) => ({ isExpression: false, value })
 
+// Which camera these buttons belong to. props.config is only filled when the *connection* itself is
+// being upgraded; upgrading buttons hands it over as null, and reconciling a UE160's buttons against
+// the generic `Other` action set reintroduces exactly the invalid option this file exists to repair.
+// The context is the field documented as "current configuration of the module", so it comes first.
+const configOf = (context, props) => context?.currentConfig ?? props.config ?? { model: 'Other' }
+
 // 2.0 validates every declared option; an option a stored button never got is invalid (undefined is
 // "not in the dropdown choices") and takes the whole action down, even when hidden. Reconciles
 // on-disk buttons against the definitions, as presets.js already does for presets we hand out.
-function fillOmittedOptions(_context, props) {
+function fillOmittedOptions(context, props) {
 	const result = { updatedActions: [], updatedConfig: null, updatedFeedbacks: [] }
 
 	// Options and defaults are model-dependent, so build definitions as the running instance does.
@@ -24,7 +30,7 @@ function fillOmittedOptions(_context, props) {
 	let actionSpecs, feedbackSpecs
 	try {
 		const self = {
-			config: props.config ?? { model: 'Other' },
+			config: configOf(context, props),
 			data: { model: null, modelAuto: null, series: null, presetThumbnails: [] },
 		}
 		actionSpecs = optionSpecs(getActionDefinitions(self))
@@ -85,7 +91,7 @@ function toPresetIndex(stored, max) {
 function presetCount(config) {
 	try {
 		const self = {
-			config: config ?? { model: 'Other' },
+			config,
 			data: { model: null, modelAuto: null, series: null, presetThumbnails: [] },
 		}
 		return getAndUpdateSeries(self).capabilities.preset || 100
@@ -94,9 +100,9 @@ function presetCount(config) {
 	}
 }
 
-function dropUseVarToggles(_context, props) {
+function dropUseVarToggles(context, props) {
 	const result = { updatedActions: [], updatedConfig: null, updatedFeedbacks: [] }
-	const max = presetCount(props.config)
+	const max = presetCount(configOf(context, props))
 
 	// Keyed on the options a button carries, not on action ids: the stepped options come from one
 	// shared builder used by many actions, so an id list would miss half of them.

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -130,6 +130,83 @@ function dropUseVarToggles(context, props) {
 	return result
 }
 
+// The value the current model's definition would accept in place of a stored one it would not.
+// Companion drops the whole entity over a single dropdown value outside `choices`, so putting the
+// model's own default back is strictly better than leaving the button dead — which is also why a
+// value stranded by the operator switching models afterwards is repaired here rather than left.
+function reconcileValue(option, field) {
+	if (field.type !== 'dropdown') return option // number fields are clamped by the callback
+
+	const ids = field.choices.map((choice) => choice.id)
+	if (ids.includes(option.value)) return option
+
+	// The preset dropdown is the one that takes any index (allowInvalidValues) and constrains it, so
+	// its stored number only needs bringing back into the range this model actually has.
+	if (field.allowInvalidValues) {
+		const idx = parseInt(option.value, 10)
+		if (!Number.isFinite(idx)) return option
+		return wrap(
+			constrainRange(idx, 0, ids.length - 1)
+				.toString(10)
+				.padStart(2, '0'),
+		)
+	}
+
+	return field.default === undefined ? option : wrap(field.default)
+}
+
+// v2.0.0 shipped the two scripts above writing bare values, and resolving the model from a
+// props.config that is null whenever buttons rather than the connection are being upgraded. Companion
+// tracks upgrade progress by index, so neither slot ever runs again for a connection that already
+// passed through 2.0.0 — appending is the only way to reach those buttons. For a connection coming
+// straight from 1.x this is a no-op: the repaired slots already wrote the right shape, from the right
+// model.
+function repairPre201Writes(context, props) {
+	const result = { updatedActions: [], updatedConfig: null, updatedFeedbacks: [] }
+
+	let actionSpecs, feedbackSpecs
+	try {
+		const self = {
+			config: configOf(context, props),
+			data: { model: null, modelAuto: null, series: null, presetThumbnails: [] },
+		}
+		actionSpecs = optionSpecs(getActionDefinitions(self))
+		feedbackSpecs = optionSpecs(getFeedbackDefinitions(self))
+	} catch {
+		return result // unresolvable model: nothing to reconcile against
+	}
+
+	const repair = (entities, idKey, specs, updated) => {
+		for (const entity of entities ?? []) {
+			const spec = specs[entity[idKey]]
+			if (!spec || !entity.options) continue
+
+			let changed = false
+			for (const [id, stored] of Object.entries(entity.options)) {
+				const field = spec.fields[id]
+				if (!field) continue
+
+				// unwrap() returns the stored object itself when it is already a wrapper, so an identity
+				// check is what separates "was written bare" from "was already fine".
+				const option = unwrap(stored)
+				const fixed = option.isExpression ? option : reconcileValue(option, field)
+
+				if (fixed !== stored) {
+					entity.options[id] = fixed
+					changed = true
+				}
+			}
+
+			if (changed) updated.push(entity)
+		}
+	}
+
+	repair(props.actions, 'actionId', actionSpecs, result.updatedActions)
+	repair(props.feedbacks, 'feedbackId', feedbackSpecs, result.updatedFeedbacks)
+
+	return result
+}
+
 export const upgradeScripts = [
 	// Was addSetIncDecVariables. Blanked, not deleted: upgrade progress is tracked by index.
 	EmptyUpgradeScript,
@@ -155,4 +232,5 @@ export const upgradeScripts = [
 	// Upgrade progress is tracked by index, so new scripts go last.
 	fillOmittedOptions,
 	dropUseVarToggles,
+	repairPre201Writes,
 ]

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -6,6 +6,12 @@ import { constrainRange, getAndUpdateSeries, optionSpecs } from './common.js'
 // Leftovers from the "Use Variable" construct, dropped from every button that carries them.
 const DEAD_OPTIONS = ['useVar', 'setVar', 'stepVar', 'valVar', 'optionVar']
 
+// An upgrade script's options are CompanionMigrationOptionValues: every entry is an
+// ExpressionOrValue wrapper, with none of the "raw value also accepted" leniency preset options get.
+// A bare write reads back as `.value === undefined`, which is exactly the invalid option these
+// scripts exist to repair. Everything written to an entity's options goes through here.
+const wrap = (value) => ({ isExpression: false, value })
+
 // 2.0 validates every declared option; an option a stored button never got is invalid (undefined is
 // "not in the dropdown choices") and takes the whole action down, even when hidden. Reconciles
 // on-disk buttons against the definitions, as presets.js already does for presets we hand out.
@@ -37,7 +43,7 @@ function fillOmittedOptions(_context, props) {
 			if (omitted.length === 0) continue
 
 			entity.options = { ...entity.options }
-			for (const id of omitted) entity.options[id] = spec.defaults[id]
+			for (const id of omitted) entity.options[id] = wrap(spec.defaults[id])
 			updated.push(entity)
 		}
 	}
@@ -133,7 +139,7 @@ export const upgradeScripts = [
 				case 'ptSpeed':
 				case 'zoomSpeed':
 				case 'focusSpeed':
-					action.options.step = action.options.step === undefined ? 1 : action.options.step
+					if (action.options.step === undefined) action.options.step = wrap(1)
 					result.updatedActions.push(action)
 					break
 			}

--- a/src/variables.js
+++ b/src/variables.js
@@ -1,8 +1,8 @@
-import { constrainRange, getAndUpdateSeries, getLabel } from './common.js'
+import { constrainRange, seriesOf, getLabel } from './common.js'
 import { e } from './enum.js'
 
 export function setVariables(self) {
-	const SERIES = getAndUpdateSeries(self)
+	const SERIES = seriesOf(self)
 	const caps = SERIES.capabilities
 
 	// [capability guard, variables it unlocks]. Guard is a capability key or a predicate.
@@ -122,7 +122,7 @@ export function setVariables(self) {
 }
 
 export function checkVariables(self) {
-	const SERIES = getAndUpdateSeries(self)
+	const SERIES = seriesOf(self)
 
 	// [variable, capability, choices or fn(capability), data key if it differs]
 	const LABELLED = [


### PR DESCRIPTION
Works through every finding of the external module review of v2.0.0
([review-panasonic-cameras-v2.0.0-20260806-212257.md](https://github.com/digitaldrummerj/companion-module-review/blob/main/reviews/panasonic-cameras/review-panasonic-cameras-v2.0.0-20260806-212257.md), verdict ❌ Changes Required).

One commit per review section, blockers first.

### Blocking

| | |
| --- | --- |
| **C1** | `.gitignore` gains the template entries `package-lock.json`, `/*.tgz`, `/.yarn`; duplicated `.vscode/` dropped |
| **C3** | `Panasonic` removed from the manifest keywords — the manufacturer is already carried by `name`/`manufacturer` |
| **C5** | `fillOmittedOptions`/`addSetStepSize` wrote bare option values where `CompanionMigrationOptionValues` requires the `{ isExpression, value }` wrapper. Companion read those as `.value === undefined` — the very invalid option the script exists to repair. Both now route through one `wrap()` |
| **H1** | `LICENSE` uses the template's `Copyright (c) 2022 Bitfocus AS - Open Source` |
| **H4** | Nothing cancelled a pending re-init when a later request succeeded, so one dropped keep-alive stopped polling and re-published every action, feedback, variable and preset. New `onRequestSucceeded()` resets the streak and clears the retry; the connection is only declared lost after 3 consecutive reachability failures, with a fallback timer below that so a connection with no polling is not left unattended |
| **H5** | Both upgrade scripts resolved the model from `props.config`, which is `null` whenever buttons rather than the connection are being upgraded. They now read `context.currentConfig` first — otherwise a UE160's buttons were reconciled against the generic `Other` action set, and an AW-HE2 clamped presets to `'99'` instead of `'08'` |

### Non-blocking

| | |
| --- | --- |
| **M7** | `fS`/`zS` are only stored when finite. `NaN` used to publish as a variable, satisfy the `zoomControl` feedback (`NaN != 0`) so the button latched lit, and reach the camera as a literal `#ZNaN` |
| **M8** | `EADDRINUSE` closes and clears `this.server`, so `teardown()` no longer sends a goodbye for a subscription that was never made; the handler's own unsubscribe call is gone |
| **M9** | Every parse goes through `parseSafely()`, so one bad line costs that line instead of the 390 behind it — and never reaches `handleConnectionError`, which reported the resulting `TypeError` as a camera fault with the connection deadened. An error carrying no `code` is now named as a module error |
| **M10** | AK-UB300 Master Pedestal gains `step`/`hexlen`; without them every Increase/Decrease returned with no command and no log |
| **L12** | `checkVariables()` ran two model-table scans and mutated instance state after *every* response. New `seriesOf()` reads the series `reInitAll()` already resolved |

### Verification

- `yarn lint` and `yarn prettier --check .` clean
- **596 tests passing**, up from 465
- `yarn package` builds; baked manifest carries `apiVersion: 2.0.4`, `type: connection`, version 2.0.1
- Entrypoint smoke-tested: `default` is a constructor, `UpgradeScripts` is an array of 4

Two notes on the review itself:

- **M8** — the report expected `close()` on a never-listening server to re-enter the `'error'` handler with `ERR_SERVER_NOT_RUNNING`. Checked against node 22: `net.Server.close()` routes that to its callback and emits nothing, so there was no spurious log. The other consequence (the bogus goodbye) was real and is fixed.
- **M10** — rather than having `optSetStepped` throw on a missing `step`/`hexlen` (a throw while building definitions would take the connection down), `definitions.test.js` now asserts across every `SERIES_SPECS` entry that a level capability carries both. Reverting the `models.js` line fails it. `resolveSetStep()` also logs which option would not resolve instead of aborting in silence.

### Still to check in a real Companion host

Draft until these are done — neither is reachable from the test suite:

1. Upgrade a **v1.2.0-saved config with buttons** (C5 + H5). This runs once per existing user and is unrecoverable if wrong.
2. Reconnect behaviour (H4): a brief outage must leave the status on `Ok`; three consecutive failures must give `ConnectionFailure → Connecting → Ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)